### PR TITLE
correct Windows path for Streamlit executable in venv

### DIFF
--- a/src/app/settings.py
+++ b/src/app/settings.py
@@ -1,3 +1,4 @@
+import sys
 from pathlib import Path
 
 from pydantic_settings import BaseSettings, SettingsConfigDict
@@ -42,6 +43,8 @@ class _Settings(BaseSettings):
 
     @property
     def UI_EXECUTABLE(self) -> Path:
+        if sys.platform == "win32":
+            return self.ROOT_PATH / ".venv/Scripts/streamlit.exe"
         return self.ROOT_PATH / ".venv/bin/streamlit"
 
     @property


### PR DESCRIPTION
# Pull Request Template

## Summary

bugfix: correct Windows path for Streamlit executable in venv
feat(platform): make UI_EXECUTABLE platform-aware (Windows + POSIX)
chore: add win32 branch for Streamlit path (.venv/Scripts/streamlit.exe)

## Checklist

### Code & Implementation
- [ X] Have you run `uv run poe format` and fixed all warnings before submitting
this PR?
- [ ] Is all the logic in services instead of endpoints?
- [X ] Is the code self-explanatory without requiring comments or documentation?

### Machine Learning Specific
- [ ] Are the data preprocessing steps reproducible? (e.g., deterministic pipelines, seeds set).
- [ ] Model changes are tracked with experiment tracker (e.g., versioned
artifacts, experiment logs).
- [ ] Can all the notebooks be run top to bottom?
- [ ] Are all the notebooks outputs cleared?

### Documentation
- [ ] Relevant README or docs updated.

---

### Reviewer Guidance
- Ensure clarity: Could the reviewer understand the purpose of the PR without
asking?
- Ensure reproducibility: Could you re-run the experiment or training with the
given code and instructions?
- Ensure maintainability: Does the structure fit into the long-term system
design?
